### PR TITLE
Handle 503 Service Unavailable

### DIFF
--- a/Source/Turbo/TurboError.swift
+++ b/Source/Turbo/TurboError.swift
@@ -6,6 +6,7 @@ public enum TurboError: LocalizedError, Equatable {
     case timeoutFailure
     case contentTypeMismatch
     case pageLoadFailure
+    case serviceUnavailable
     case http(statusCode: Int)
 
     init(statusCode: Int) {
@@ -16,6 +17,8 @@ public enum TurboError: LocalizedError, Equatable {
             self = .timeoutFailure
         case -2:
             self = .contentTypeMismatch
+        case 503:
+            self = .serviceUnavailable
         default:
             self = .http(statusCode: statusCode)
         }
@@ -31,6 +34,8 @@ public enum TurboError: LocalizedError, Equatable {
             return "The server returned an invalid content type."
         case .pageLoadFailure:
             return "The page could not be loaded due to a configuration error."
+        case .serviceUnavailable:
+            return "The service is temporarily unavailable."
         case .http(let statusCode):
             return "There was an HTTP error (\(statusCode))."
         }

--- a/Tests/Turbo/Server.swift
+++ b/Tests/Turbo/Server.swift
@@ -33,6 +33,9 @@ extension DefaultHTTPServer {
                 startResponse("200 OK", [("Content-Type", "text/html")])
                 sendBody("<html></html>".data(using: .utf8)!)
                 sendBody(Data())
+            case "/service-unavailable":
+                startResponse("503 Service Unavailable", [("Content-Type", "text/plain")])
+                sendBody(Data())
             default:
                 startResponse("404 Not Found", [("Content-Type", "text/plain")])
                 sendBody(Data())

--- a/Tests/Turbo/SessionTests.swift
+++ b/Tests/Turbo/SessionTests.swift
@@ -88,6 +88,14 @@ class SessionTests: XCTestCase {
         XCTAssertEqual(error as? TurboError, TurboError.http(statusCode: 404))
     }
 
+    func test_coldBootVisit_whenServiceUnavailable_providesServiceUnavailableError() async throws {
+        await visit("/service-unavailable")
+
+        XCTAssertNotNil(sessionDelegate.failedRequestError)
+        let error = try XCTUnwrap(sessionDelegate.failedRequestError)
+        XCTAssertEqual(error as? TurboError, TurboError.serviceUnavailable)
+    }
+
     func test_coldBootVisit_whenVisitFailsFromHTTPError_callsSessionDidFinishRequestDelegateMethod() async {
         await visit("/invalid")
 


### PR DESCRIPTION
Adds an explicit 503 error to support kamal's (and other PaaS) [maintenance mode](https://deploymentfromscratch.com/blog/kamal-maintenance-mode) out of the box.